### PR TITLE
Upgrade strategies to Freqtrade v3 API and update dependencies

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,8 @@
 version: '3'
 services:
   freqtrade:
-    image: freqtradeorg/freqtrade:stable
+    image: freqtradeorg/freqtrade:2026.1
+    # image: freqtradeorg/freqtrade:stable
     # image: freqtradeorg/freqtrade:develop
     # Use plotting image
     # image: freqtradeorg/freqtrade:develop_plot

--- a/user_data/strategies/ReinforcedSmoothScalp.py
+++ b/user_data/strategies/ReinforcedSmoothScalp.py
@@ -8,7 +8,7 @@ from technical.util import resample_to_interval, resampled_merge
 import numpy  # noqa
 # --------------------------------
 import talib.abstract as ta
-import freqtrade.vendor.qtpylib.indicators as qtpylib
+from technical import qtpylib
 
 
 class ReinforcedSmoothScalp(IStrategy):

--- a/user_data/strategies/SlopeIsDope.py
+++ b/user_data/strategies/SlopeIsDope.py
@@ -1,15 +1,18 @@
 # --- Do not remove these libs ---
-from freqtrade.strategy.interface import IStrategy
+from freqtrade.strategy import IStrategy
 from pandas import DataFrame
 # --------------------------------
 
 # Add your lib to import here
 import talib.abstract as ta
-import freqtrade.vendor.qtpylib.indicators as qtpylib
+from technical import qtpylib
 from scipy.spatial.distance import cosine
 import numpy as np
 
 class SlopeIsDope(IStrategy):
+
+    INTERFACE_VERSION: int = 3
+
     # Minimal ROI designed for the strategy.
     minimal_roi = {
         "0": 0.6
@@ -18,7 +21,7 @@ class SlopeIsDope(IStrategy):
     stoploss = -0.9
 
     timeframe = '4h'
-    
+
     # Trailing stoploss
     trailing_stop = False
     trailing_only_offset_is_reached = False
@@ -68,7 +71,7 @@ class SlopeIsDope(IStrategy):
     }
 
 
-    def populate_buy_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+    def populate_entry_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         dataframe.loc[
             (
                 # Only enter when market is bullish (this is a choice)
@@ -90,20 +93,20 @@ class SlopeIsDope(IStrategy):
                 # (qtpylib.crossed_above(dataframe['fastMA'], dataframe['slowMA']))
                 )
             ),
-            'buy'] = 1
+            'enter_long'] = 1
 
         return dataframe
 
-    def populate_sell_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+    def populate_exit_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         dataframe.loc[
             (
 
                 # Close or do not trade when fastMA is below slowMA
                 (dataframe['fastMA'] < dataframe['slowMA'])
                 # Or close position when the close price gets below the last lowest candle price configured
-                # (AKA candle based (Trailing) stoploss) 
+                # (AKA candle based (Trailing) stoploss)
                 | (dataframe['close'] < dataframe['last_lowest'])
                 # | (dataframe['close'] < dataframe['fastMA'])
             ),
-            'sell'] = 1
+            'exit_long'] = 1
         return dataframe

--- a/user_data/strategies/VWAPBandMeanReversionScalp.py
+++ b/user_data/strategies/VWAPBandMeanReversionScalp.py
@@ -8,7 +8,7 @@ from datetime import datetime
 import numpy as np
 # --------------------------------
 import talib.abstract as ta
-import freqtrade.vendor.qtpylib.indicators as qtpylib
+from technical import qtpylib
 
 
 class VWAPBandMeanReversionScalp(IStrategy):


### PR DESCRIPTION
## Summary
This PR updates multiple trading strategies to be compatible with Freqtrade v3 API while also updating the Docker image version and modernizing imports.

## Key Changes

### Strategy API Updates
- **SlopeIsDope.py**: 
  - Added `INTERFACE_VERSION: int = 3` to declare v3 API compatibility
  - Renamed `populate_buy_trend()` to `populate_entry_trend()`
  - Renamed `populate_sell_trend()` to `populate_exit_trend()`
  - Updated signal column names from `'buy'`/`'sell'` to `'enter_long'`/`'exit_long'`

### Import Modernization
- Updated import statements across all strategies:
  - Changed `from freqtrade.strategy.interface import IStrategy` to `from freqtrade.strategy import IStrategy`
  - Replaced `import freqtrade.vendor.qtpylib.indicators as qtpylib` with `from technical import qtpylib` in:
    - SlopeIsDope.py
    - ReinforcedSmoothScalp.py
    - VWAPBandMeanReversionScalp.py

### Infrastructure
- Updated Docker image version from `freqtradeorg/freqtrade:stable` to `freqtradeorg/freqtrade:2026.1`
- Commented out the stable tag for reference

### Code Quality
- Fixed trailing whitespace issues in SlopeIsDope.py

## Implementation Details
These changes align with Freqtrade v3's breaking API changes where the strategy interface was simplified and signal column naming was standardized. The qtpylib import change reflects the library's relocation to the `technical` package, which is now the recommended approach.

https://claude.ai/code/session_01YNVPEjX7fHsewNFAUqX8Qm