### PR TITLE
Remove Docker Compose version specification

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 ---
-version: '3'
 services:
   freqtrade:
     image: freqtradeorg/freqtrade:2026.1


### PR DESCRIPTION
## Summary
Removed the explicit `version: '3'` declaration from the docker-compose.yml file.

## Key Changes
- Removed the `version: '3'` line from docker-compose.yml

## Implementation Details
Docker Compose will now use the default version based on the installed Docker Compose CLI version. This aligns with modern Docker Compose practices where the version specification is optional and the tool automatically determines compatibility based on the schema used in the file.

https://claude.ai/code/session_01Cm5MbnajEvC1VXPUXyM7U9